### PR TITLE
bundle typings with package

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "files": [
     "builds/",
-    "docs/"
+    "docs/",
+    "compromise.d.ts"
   ],
   "dependencies": {
     "efrt-unpack": "2.0.3"


### PR DESCRIPTION
Currently the package.json includes a types property but the referenced file isn't being included when publishing to NPM.  This change should now bundle the typings file during a publish.