### PR TITLE
Fixes wildcards with capture groups

### DIFF
--- a/src/terms/match/lib/applyCaptureGroup.js
+++ b/src/terms/match/lib/applyCaptureGroup.js
@@ -1,0 +1,10 @@
+'use strict';
+//applies the reg capture group setting to the term
+const applyCaptureGroup = (term, reg) => {
+  if (reg.capture) {
+    term.captureGroup = true;
+  } else {
+    term.captureGroup = undefined;
+  }
+};
+module.exports = applyCaptureGroup;

--- a/src/terms/match/lib/isMatch.js
+++ b/src/terms/match/lib/isMatch.js
@@ -1,4 +1,5 @@
 'use strict';
+const applyCaptureGroup = require('./applyCaptureGroup');
 
 //compare 1 term to one reg
 const perfectMatch = (term, reg) => {
@@ -56,15 +57,13 @@ const isMatch = (term, reg, verbose) => {
     return false;
   }
   let found = perfectMatch(term, reg, verbose);
-  //flag it as a capture-group
-  if (reg.capture) {
-    term.captureGroup = true;
-  } else {
-    term.captureGroup = undefined;
-  }
   //reverse it for .not()
   if (reg.negative) {
     found = !Boolean(found);
+  }
+  if (found) {
+    //only apply capture group settings to matches
+    applyCaptureGroup(term, reg);
   }
   return found;
 };

--- a/test/unit/match/capture.test.js
+++ b/test/unit/match/capture.test.js
@@ -17,6 +17,15 @@ test('match-capture-group', function(t) {
   m = nlp('i saw ralf eat the glue Mrs. Hoover').match('ralf [#Verb the glue] mrs');
   t.equal(m.out('normal'), 'eat the glue', 'three-word capture');
 
+  m = nlp('ralf eats the glue').match('* [#Verb]');
+  t.equal(m.out('normal'), 'eats', 'capture after wildcard');
+
+  m = nlp('ralf eats the glue').match('ralf eats [*]');
+  t.equal(m.out('normal'), 'the glue', 'wildcard capture at the end');
+
+  m = nlp('ralf eats the glue').match('ralf eats [*] glue');
+  t.equal(m.out('normal'), 'the', 'wildcard capture in the middle');
+
   m = nlp('saw the Toronto International Documentary Film Festival yesterday').match('saw the? [#Noun+] yesterday');
   t.equal(m.trim().out('text'), 'Toronto International Documentary Film Festival', 'greedy capture');
 


### PR DESCRIPTION
Currently, if a capture group is directly after a wildcard, the wildcard terms are added to the capture group. Additionally, wildcard capture groups return the entire match, instead of just the wildcard terms.

This only applies capture group settings to the term if the term is a match, and also applies capture group settings for wildcards to the wildcard matching terms.