### PR TITLE
Plural option in normalize is non-cooperative

### DIFF
--- a/test/unit/result/normalize.test.js
+++ b/test/unit/result/normalize.test.js
@@ -62,6 +62,45 @@ test('optional params', function(t) {
   t.end();
 });
 
+test.only('optional param - verbs and plurals together', function(t) {
+  var plurals = [
+    ['batmobiles', 'batmobile'],
+  ];
+  var verbs = [
+    ['I was walking', 'i walk'],
+  ];
+
+  // good
+  plurals.forEach((a) => {
+    var doc = nlp(a[0]);
+    var pluralsOn = doc.normalize({
+      plurals: true,
+    });
+    t.equal(pluralsOn.out(), a[1], a[0]);
+  });
+
+  // good
+  verbs.forEach((a) => {
+    var doc = nlp(a[0]);
+    var verbsOn = doc.normalize({
+      verbs: true,
+    });
+    t.equal(verbsOn.out(), a[1], a[0]);
+  });
+
+  // bad
+  plurals.concat(verbs).forEach((a) => {
+    var doc = nlp(a[0]);
+    var bothOn = doc.normalize({
+      plurals: true,
+      verbs: true,
+    });
+    t.equal(bothOn.out(), a[1], a[0]);
+  });
+
+  t.end();
+});
+
 test('honorifics', function(t) {
   var tests = [
     ['rear admiral Smith', 'smith'],


### PR DESCRIPTION
Hey!! :)

Didn't see an issue for this, so making a placeholder here.

I was trying to use `plural` and `verbs` options together for normalize and found they don't work.

So I added this test. Then went looking in the code and also found:

`plurals: r => { //todo:this has a non-cooperative bug` (src/text/methods/normalize.js)

So looks like it is known about. I havn't had a chance to help looking into a fix yet though.

I also left this test as `.only`, was thinking to remove that when the fix is in this branch (and perhaps remove those two un-needed green tests).

