### PR TITLE
Make sure that types are included in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "files": [
     "builds/",
     "docs/",
-    "compromise.d.ts"
+    "types/index.d.ts"
   ],
   "prettier": {
     "trailingComma": "none",


### PR DESCRIPTION
#596 fixed the typings but also moved the `.d.ts` file without updating the `files` entry in `package.json` - the outcome is that compromise >= 11.14.0 doesn't include type definitions in npm package at all. This PR fixes that.