### PR TITLE
Fix duplicate named groups

### DIFF
--- a/tests/match/named-match.test.js
+++ b/tests/match/named-match.test.js
@@ -250,17 +250,22 @@ test('named-match-code-gen', function(t) {
     {
       name: 'SetSize',
       match: '[<type>#Noun] size equals [<size>#Adjective]',
-      fn: ({ size, type }) => `=== Info\n${size.text()}\n${type.text()}`,
+      fn: ({ size, type }) => `${type.text()}.size = ${size.text()}`,
+    },
+    {
+      name: 'If',
+      match: 'If [<a>#Verb] equals [<b>#Value] then',
+      fn: ({ a, b }) => `if(${a.text()} === ${b.text()}){}`,
     },
   ]
 
   // Plugin for post processing matches and thunking the output
-  const codeNlp = nlp.extend((Doc, world) => {
-    Doc.prototype.generators = []
+  const code = (Doc, world) => {
+    world.generators = []
     Doc.prototype.toCode = function() {
       let output = ''
 
-      for (const g of this.generators) {
+      for (const g of world.generators) {
         output += g()
       }
 
@@ -271,15 +276,26 @@ test('named-match-code-gen', function(t) {
       for (let i = 0; i < templates.length; i++) {
         const template = templates[i]
 
-        const res = doc.match(template.match).byName()
-        doc.generators.push(() => template.fn(res))
+        const res = doc.if(template.match)
+        if (res.found) {
+          world.generators.push(() => template.fn(res.byName()))
+        }
       }
     })
-  })
+  }
+
+  let output = nlp
+    .clone()
+    .extend(code)('if size equals 0 then')
+    .toCode()
+  t.equal(output, 'if(size === 0){}')
 
   // Use code generators
-  const output = codeNlp('Dog size equals big').toCode()
-  t.equal(output, '=== Info\nbig\nDog')
+  output = nlp
+    .clone()
+    .extend(code)('Dog size equals big')
+    .toCode()
+  t.equal(output, 'Dog.size = big')
 
   t.end()
 })

--- a/tests/match/named-match.test.js
+++ b/tests/match/named-match.test.js
@@ -260,28 +260,21 @@ test('named-match-code-gen', function(t) {
   ]
 
   // Plugin for post processing matches and thunking the output
-  const code = (Doc, world) => {
-    world.generators = []
+  const code = Doc => {
     Doc.prototype.toCode = function() {
       let output = ''
 
-      for (const g of world.generators) {
-        output += g()
+      for (let i = 0; i < templates.length; i++) {
+        const template = templates[i]
+
+        const res = this.if(template.match)
+        if (res.found) {
+          output += template.fn(res.byName())
+        }
       }
 
       return output
     }
-
-    world.postProcess(doc => {
-      for (let i = 0; i < templates.length; i++) {
-        const template = templates[i]
-
-        const res = doc.if(template.match)
-        if (res.found) {
-          world.generators.push(() => template.fn(res.byName()))
-        }
-      }
-    })
   }
 
   let output = nlp

--- a/tests/match/named-match.test.js
+++ b/tests/match/named-match.test.js
@@ -254,8 +254,8 @@ test('named-match-code-gen', function(t) {
     },
     {
       name: 'If',
-      match: 'If [<a>#Verb] equals [<b>#Value] then',
-      fn: ({ a, b }) => `if(${a.text()} === ${b.text()}){}`,
+      match: 'If [<a>#Verb] equals [<b>#Value] then [<contents>.+]',
+      fn: ({ a, b, contents }) => `if(${a.text()} === ${b.text()}){${contents.text()}}`,
     },
   ]
 
@@ -279,9 +279,9 @@ test('named-match-code-gen', function(t) {
 
   let output = nlp
     .clone()
-    .extend(code)('if size equals 0 then')
+    .extend(code)('if size equals 0 then do this, and this, and this')
     .toCode()
-  t.equal(output, 'if(size === 0){}')
+  t.equal(output, 'if(size === 0){do this, and this, and this}')
 
   // Use code generators
   output = nlp


### PR DESCRIPTION
Not fixed yet, just made the PR so you're aware.

Since named groups are given a unique id, seeing duplicates when used in a plugin where we do a named match as part of a postProcess - see `named-match.test.js`

Might be an issue of clone not using fresh Doc?
Post process runs over my input 3 times (correct Doc), even though I'm only using the plugin twice.