### PR TITLE
Fix

### DIFF
--- a/src/Doc/methods/02-accessors.js
+++ b/src/Doc/methods/02-accessors.js
@@ -85,7 +85,13 @@ const getOneName = function(doc, name) {
   for (let i = 0; i < doc.list.length; i++) {
     const phrase = doc.list[i]
     let keys = Object.keys(phrase.names)
-    keys = keys.filter(id => phrase.names[id].group === name)
+    keys = keys.filter(id => {
+      if (phrase.names[id].group !== undefined) {
+        return phrase.names[id].group === name
+      }
+
+      return phrase.names[id].index === name
+    })
     keys.forEach(id => {
       arr.push(phrase.buildFrom(phrase.names[id].start, phrase.names[id].length))
     })

--- a/tests/match/named-match.test.js
+++ b/tests/match/named-match.test.js
@@ -13,12 +13,31 @@ test('named-match-auto:', function(t) {
   ]
 
   arr.forEach(function(a) {
-    const doc = nlp(a[0])
-      .match(a[1])
-      .byName(0)
+    const doc = nlp(a[0]).match(a[1])
+
+    const res = doc.byName(0)
 
     const msg = a[0] + ' matches ' + JSON.stringify(a[1]) + ' ' + a[2]
-    t.equal(doc.text(), a[2], msg)
+    t.equal(res.text(), a[2], msg)
+  })
+
+  t.end()
+})
+
+test('named-match-auto-multi:', function(t) {
+  let arr = [
+    ['the dog played', 'the [#Noun] [played]', 'dog played'],
+    ['the dog played lots', 'the [dog] played [<0>lots]', 'dog lots'],
+    ['the big dog played', 'the [big dog] [played]', 'big dog played'],
+  ]
+
+  arr.forEach(function(a) {
+    const doc = nlp(a[0]).match(a[1])
+
+    const res = doc.byName(0)
+
+    const msg = a[0] + ' matches ' + JSON.stringify(a[1]) + ' ' + a[2]
+    t.equal(res.text(), a[2], msg)
   })
 
   t.end()

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -75,8 +75,10 @@ type PluginWorld<D extends object, W extends object> = {
 
 type PluginDocument<D extends object, W extends object> = nlp.ExtendedDocument<D, W> & { prototype: D }
 
+type PluginTerm = nlp.Term & PluginConstructor
+
 // Make these available, full support tbd
-type PluginConstructors = {
+type PluginConstructor = {
   prototype: Record<string, any>
 }
 
@@ -100,9 +102,9 @@ declare module nlp {
     Doc: PluginDocument<D, W>,
     world: PluginWorld<D, W>,
     nlp: nlp<D, W>,
-    Phrase: PluginConstructors,
-    Term: Term, // @todo Add extend support
-    Pool: PluginConstructors
+    Phrase: PluginConstructor,
+    Term: PluginTerm, // @todo Add extend support
+    Pool: PluginConstructor
   ) => void
 
   type ExtendedWorld<W extends object> = nlp.World & W


### PR DESCRIPTION
So index is only used if no name and named groups are always made for capture groups. Probably doesn't need to be called "named" anymore!

Function might be nice to return the array of non-named capture groups