### PR TITLE
Some fixes

### DIFF
--- a/src/Doc/methods/02-accessors.js
+++ b/src/Doc/methods/02-accessors.js
@@ -68,11 +68,13 @@ const getGroups = function(doc) {
     const phrase = doc.list[i]
     const groups = Object.keys(phrase.groups).map(k => phrase.groups[k])
     for (let j = 0; j < groups.length; j++) {
-      const { group, start, length } = groups[j]
-      if (!allGroups[group]) {
-        allGroups[group] = []
+      const { group, start, length, index } = groups[j]
+      const groupName = group === undefined ? index : group
+
+      if (!allGroups[groupName]) {
+        allGroups[groupName] = []
       }
-      allGroups[group].push(phrase.buildFrom(start, length))
+      allGroups[groupName].push(phrase.buildFrom(start, length))
     }
   }
   const keys = Object.keys(allGroups)

--- a/src/Phrase/match/03-tryMatch.js
+++ b/src/Phrase/match/03-tryMatch.js
@@ -80,7 +80,7 @@ const tryHere = function(terms, regs, index, length) {
     // Reuse previous capture group if same
     if (hasGroup) {
       const prev = regs[r - 1]
-      if (prev && prev.named === reg.named && previousGroupId) {
+      if (prev && prev.named !== true && prev.named === reg.named && previousGroupId) {
         namedGroupId = previousGroupId
       } else {
         groupCounter++

--- a/tests/match/named-silent.test.js
+++ b/tests/match/named-silent.test.js
@@ -33,8 +33,8 @@ test('unnamed capture groups found', function(t) {
   t.equal(m.groups(1).text(), 'four', 'unnamed-found-1')
 
   let groups = m.groups()
-  t.equal(groups['0'].text(), 'two', 'groups-0')
-  t.equal(groups['0'].text(), 'four', 'groups-1')
+  t.equal(groups[0].text(), 'two', 'groups-0')
+  t.equal(groups[1].text(), 'four', 'groups-1')
 
   t.end()
 })


### PR DESCRIPTION
So current problems:
* undefined group name - fixed
* Not incrementing group number (didn't check for true) - fixed

Last one breaks some two-word capture, because groups aren't being merged together...without it `[a] test [b]` gets merged into one, which it shouldn't.

Basically, need another look at postProcess in Doc/syntax as we want to ensure we fill in gaps for a named capture group, but don't join unnamed groups together.
Might be worth giving unnamed group a named during parseToken, with a group counter in syntax...
I might not have time to look more until tonight.