### PR TITLE
Add "release" workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,8 +3,11 @@ name: Build and test
 on: [pull_request]
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
+
+    env:
+      CI: true
 
     strategy:
       matrix:
@@ -27,18 +30,25 @@ jobs:
             ${{ runner.os }}-npm-${{ matrix.node-version }}-
             ${{ runner.os }}-npm-
 
-      - name: npm install, build, and test
+      - name: install
         run: |
           npm ci
           npm i --no-save eslint ts-node typescript
           npm run plugins:ci
+
+      - name: static checks
+        run: |
           npm run lint
+
+      - name: build
+        run: |
           npm run build
           npm run plugins:build
+
+      - name: test
+      run: |
           npm run test:smoke
           npm run testb
           npm run test:perf
           npm run test:types
           # npm run test:stress
-        env:
-          CI: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,7 +46,7 @@ jobs:
           npm run plugins:build
 
       - name: test
-      run: |
+        run: |
           npm run test:smoke
           npm run testb
           npm run test:perf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    env:
+      CI: true
+
+    # Note that these steps are *identical* to build-and-test (with the caveat
+    # that build-and-test uses several versions of Node, and Release only uses
+    # 10.x) at least until the actual publishing happens.  Ideally, we could
+    # delegate to the build- and-test workflow, but I haven't found a way to do
+    # that yet.
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+
+      - name: cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-10.x-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-10.x-
+            ${{ runner.os }}-npm-
+
+      - name: install
+      run: |
+        npm ci
+        npm i --no-save eslint ts-node typescript
+        npm run plugins:ci
+
+      - name: static checks
+        run: |
+          npm run lint
+
+      - name: build
+        run: |
+          npm run build
+          npm run plugins:build
+
+      - name: test
+      run: |
+          npm run test:smoke
+          npm run testb
+          npm run test:perf
+          npm run test:types
+          # npm run test:stress
+
+      # And finally... publish it!
+      - name: publish
+        run: npm publish
+        with:
+          env:
+            NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
             ${{ runner.os }}-npm-
 
       - name: install
-      run: |
+        run: |
         npm ci
         npm i --no-save eslint ts-node typescript
         npm run plugins:ci
@@ -48,7 +48,7 @@ jobs:
           npm run plugins:build
 
       - name: test
-      run: |
+        run: |
           npm run test:smoke
           npm run testb
           npm run test:perf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,9 @@ jobs:
 
       - name: install
         run: |
-        npm ci
-        npm i --no-save eslint ts-node typescript
-        npm run plugins:ci
+          npm ci
+          npm i --no-save eslint ts-node typescript
+          npm run plugins:ci
 
       - name: static checks
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,9 +55,12 @@ jobs:
           npm run test:types
           # npm run test:stress
 
-      # And finally... publish it!
+      # And finally... publish it!  Note that we create the .npmrc file
+      # "just in time" so that `npm publish` can get the auth token from the
+      # environment
       - name: publish
-        run: npm publish --dry-run
-        with:
-          env:
-            NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
+          npm publish --dry-run
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
 
       # And finally... publish it!
       - name: publish
-        run: npm publish
+        run: npm publish --dry-run
         with:
           env:
             NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-# authenticate using NPM_TOKEN from the environment,
-# needed for "release" GitHub workflow
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# authenticate using NPM_TOKEN from the environment,
+# needed for "release" GitHub workflow
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
This is a very simple workflow to attempt to automate publishing releases to npm.  I was hoping to drive the version number in `package.json` from the GitHub release, but `npm version` would attempt to create a git tag which would conflict with the one created directly by the GitHub release process.

**Requirement:** You must have updated the intended version number in `package.json` _before_ you create the matching release in GitHub.  This will ensure that `package.json` tagged in release `X.Y.Z` says `"version": "X.Y.Z"`, and that version will also be used when publishing to npm.

**TO DO:** Four additional steps need to happen to make this work:
1. You'll need to create an npm authentication token via https://www.npmjs.com/settings/spencermountain/tokens.
2. You'll need to add this token as a secret named `NPM_TOKEN` at https://github.com/spencermountain/compromise/settings/secrets.
3. If you currently require 2FA to publish (at https://www.npmjs.com/package/compromise/access), you'll need to turn it off.
4. Once you can verify that it's doing roughly the right thing, the `--dry-run` flag should be removed from the `npm publish` command.

(The 'build-and-test' workflow was tweaked to make it easier to find failing steps... instead of having to sift through ten separate npm commands, they are bucketed into rough groups: install, lint, build, and test; each one of which is a small number of underlying npm commands.)