### PR TITLE
prevent doc offset changes (length) from clobbering term[0] offset

### DIFF
--- a/src/Doc/methods/output/_offset.js
+++ b/src/Doc/methods/output/_offset.js
@@ -39,8 +39,16 @@ const calcOffset = function(doc, result, options) {
       //   console.log(t.post)
       //   return n
       // }, 0)
-      o.offset = o.terms[0].offset
-      o.offset.length = o.text.length
+
+      // offset information for the entire doc starts at the first term, and
+      // is as long as the whole text (note that there may be an issue where
+      // leading punctuation is counted in the doc text length, but is
+      // *excluded* from the term[0] start position)
+      o.offset = Object.assign(
+        {},
+        o.terms[0].offset,
+        { length: o.text.length }
+      )
     })
   }
 }

--- a/tests/output/offset.test.js
+++ b/tests/output/offset.test.js
@@ -37,3 +37,54 @@ test('offset-punctuation', function(t) {
 
   t.end()
 })
+
+
+test('offset-terms', function(t) {
+  let doc = nlp(`hello world`)
+  let obj = doc.json({ offset: true, terms: true })[0]
+
+  t.equal(obj.offset.start, 0, 'doc-start')
+  t.equal(obj.offset.length, 11, 'doc-length')
+
+  t.equal(obj.terms[0].offset.start, 0, 'term 0-start')
+  t.equal(obj.terms[0].offset.length, 5, 'term 0-length')
+
+  t.equal(obj.terms[1].offset.start, 6, 'term 0-start')
+  t.equal(obj.terms[1].offset.length, 5, 'term 0-length')
+
+  t.end()
+})
+
+test('offset-terms-whitespace', function(t) {
+  let doc = nlp(` hello world`)
+  let obj = doc.json({ offset: true, terms: true })[0]
+
+  t.equal(obj.offset.start, 1, 'doc-start')
+  t.equal(obj.offset.length, 11, 'doc-length')
+
+  t.equal(obj.terms[0].offset.start, 1, 'term 0-start')
+  t.equal(obj.terms[0].offset.length, 5, 'term 0-length')
+
+  t.equal(obj.terms[1].offset.start, 7, 'term 0-start')
+  t.equal(obj.terms[1].offset.length, 5, 'term 0-length')
+
+  t.end()
+})
+
+test('offset-terms-punctuation', function(t) {
+  let doc = nlp(`"hello world`)
+  let obj = doc.json({ offset: true, terms: true })[0]
+
+  // The doc-level offset should perhaps be 0->12 or 1->11... but 1->12 is not
+  // really sane.  This test will need to change if/when that gets figured out.
+  t.equal(obj.offset.start, 1, 'doc-start')    // <==== arguably wrong!
+  t.equal(obj.offset.length, 12, 'doc-length') // <==== arguably wrong!
+
+  t.equal(obj.terms[0].offset.start, 1, 'term 0-start')
+  t.equal(obj.terms[0].offset.length, 5, 'term 0-length')
+
+  t.equal(obj.terms[1].offset.start, 7, 'term 0-start')
+  t.equal(obj.terms[1].offset.length, 5, 'term 0-length')
+
+  t.end()
+})


### PR DESCRIPTION
The original code assigned to the doc-level '.offset' result from the offset information from term[0].  This creates an additional reference to the same underlying object, *not* a clone of the data. When the doc-level length was then set, it clobbered the length of the term[0] offset info.

This now uses `Object.assign()` to create an all-new doc-level offset object with the same values as it had previously.

Fixes #771