### PR TITLE
Fix tokenization out-of-memory crash and slow performance for long string, few sentence case

### DIFF
--- a/src/01-tokenizer/01-sentences.js
+++ b/src/01-tokenizer/01-sentences.js
@@ -40,7 +40,7 @@ const testIsAcronym = function (str, suffix) {
   if (suffix.indexOf('.') === -1) {
     return false
   }
-  return isAcronym.test(str);
+  return isAcronym.test(str)
 }
 
 const testHasEllipse = function (str, suffix) {
@@ -48,7 +48,7 @@ const testHasEllipse = function (str, suffix) {
   if (suffix.indexOf('.') === -1) {
     return false
   }
-  return hasEllipse.test(str);
+  return hasEllipse.test(str)
 }
 
 const testHasLetter = function (str, suffix, prefixHasLetter) {
@@ -64,11 +64,11 @@ const isSentence = function (str, suffix, abbrevs, prefixContext) {
   }
   // check for 'F.B.I.'
   if (testIsAcronym(str, suffix)) {
-    return false;
+    return false
   }
   //check for '...'
   if (testHasEllipse(str, suffix)) {
-    return false;
+    return false
   }
 
   let txt = str.replace(/[.!?\u203D\u2E18\u203C\u2047-\u2049] *$/, '')

--- a/src/01-tokenizer/01-sentences.js
+++ b/src/01-tokenizer/01-sentences.js
@@ -35,19 +35,40 @@ const naiive_split = function (text) {
   return all
 }
 
-/** does this look like a sentence? */
-const isSentence = function (str, abbrevs) {
-  // check for 'F.B.I.'
-  if (isAcronym.test(str) === true) {
+const testIsAcronym = function (str, suffix) {
+  // early exit
+  if (suffix.indexOf('.') === -1) {
     return false
+  }
+  return isAcronym.test(str);
+}
+
+const testHasEllipse = function (str, suffix) {
+  // early exit
+  if (suffix.indexOf('.') === -1) {
+    return false
+  }
+  return hasEllipse.test(str);
+}
+
+const testHasLetter = function (str, suffix, prefixHasLetter) {
+  return prefixHasLetter || hasLetter.test(suffix)
+}
+
+/** does this look like a sentence? */
+const isSentence = function (str, suffix, abbrevs, prefixContext) {
+  // must have a letter
+  prefixContext.hasLetter = testHasLetter(str, suffix, prefixContext.hasLetter)
+  if (!prefixContext.hasLetter) {
+    return false
+  }
+  // check for 'F.B.I.'
+  if (testIsAcronym(str, suffix)) {
+    return false;
   }
   //check for '...'
-  if (hasEllipse.test(str) === true) {
-    return false
-  }
-  // must have a letter
-  if (hasLetter.test(str) === false) {
-    return false
+  if (testHasEllipse(str, suffix)) {
+    return false;
   }
 
   let txt = str.replace(/[.!?\u203D\u2E18\u203C\u2047-\u2049] *$/, '')
@@ -104,15 +125,20 @@ const splitSentences = function (text, world) {
 
   //detection of non-sentence chunks:
   //loop through these chunks, and join the non-sentence chunks back together..
+  let suffix = chunks[0] || ''
+  const prefixContext = { hasLetter: false }
   for (let i = 0; i < chunks.length; i++) {
     let c = chunks[i]
     //should this chunk be combined with the next one?
-    if (chunks[i + 1] && isSentence(c, abbrevs) === false) {
-      chunks[i + 1] = c + (chunks[i + 1] || '')
+    if (chunks[i + 1] && isSentence(c, suffix, abbrevs, prefixContext) === false) {
+      suffix = chunks[i + 1] || ''
+      chunks[i + 1] = c + suffix
     } else if (c && c.length > 0) {
       //&& hasLetter.test(c)
       //this chunk is a proper sentence..
       sentences.push(c)
+      suffix = chunks[i + 1] || ''
+      prefixContext.hasLetter = false
     }
     chunks[i] = ''
   }

--- a/src/01-tokenizer/01-sentences.js
+++ b/src/01-tokenizer/01-sentences.js
@@ -113,8 +113,8 @@ const splitSentences = function (text, world) {
       //&& hasLetter.test(c)
       //this chunk is a proper sentence..
       sentences.push(c)
-      chunks[i] = ''
     }
+    chunks[i] = ''
   }
   //if we never got a sentence, return the given text
   if (sentences.length === 0) {

--- a/tests/constructor.test.js
+++ b/tests/constructor.test.js
@@ -36,6 +36,20 @@ test('tokenize() accepts lexicon param', function (t) {
   t.end()
 })
 
+test('tokenize() does not crash on long string with many sentences', function (t) {
+  let text = 'The quick brown fox jumped over the lazy dog.\n'
+  text += 'Hi!\n'.repeat(100000)
+  let doc = nlp.tokenize(text)
+  t.end()
+})
+
+test('tokenize() does not crash on long string with few sentences', function (t) {
+  let text = 'The quick brown fox jumped over the lazy dog.\n'
+  text += '--\n'.repeat(100000)
+  let doc = nlp.tokenize(text)
+  t.end()
+})
+
 test('parseMatch() results are symmetric', function (t) {
   const doc = nlp(`Why doesnt ross, the largest friend, simply eat the other 5?`)
   let matches = [


### PR DESCRIPTION
We ran into a case where `compromise` crashed with an out-of-memory error. Here's a simple repro case:

```js
test('tokenize() does not crash on long string with few sentences', function (t) {
  let text = 'The quick brown fox jumped over the lazy dog.\n'
  text += '--\n'.repeat(100000)
  let doc = nlp.tokenize(text)
  t.end()
})
```

The issue is that the `chunks` array in `splitSentences` was growing in memory roughly quadratically as it processed each non-sentence chunk. The easy fix to this is to clear each chunk after processing it (i.e., move `chunks[i] = ''` out of the else block.

This fixes the OOM crash, but the performance of `splitSentences` is bad. A trace showed that we spent 50 seconds in `isSentence` in the above test case (because it's testing each of the regexes on the entire combined string, i.e., `--\n` then `--\n--\n` then `--\n--\n`, etc.). To fix that, this PR refactors the checks in `isSentence` to include early exit conditions. The total time to run that test goes from 50 seconds to ~100ms.

The code with passing the context (`prefixContext: { hasLetter: boolean }`) into the function isn't the cleanest thing ever, but that added complexity is at least all local to a single file.