### PR TITLE
Fix typo markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ _(all match methods use the [match-syntax](https://docs.compromise.cool/compromi
 - **[.people()](https://observablehq.com/@spencermountain/topics-named-entity-recognition)** - names like 'John F. Kennedy'
 - **[.places()](https://observablehq.com/@spencermountain/topics-named-entity-recognition)** - like 'Paris, France'
 - **[.organizations()](https://observablehq.com/@spencermountain/topics-named-entity-recognition)** - like 'Google, Inc'
-- **[.topics()](https://observablehq.com/@spencermountain/topics-named-entity-recognition)** - `people()` + `places()` + `organizations
+- **[.topics()](https://observablehq.com/@spencermountain/topics-named-entity-recognition)** - `people()` + `places()` + `organizations()`
 
 ##### Subsets
 


### PR DESCRIPTION
```
"`organizations" -> "`organizations()`"
```