### PR TITLE
Fix some clauses

### DIFF
--- a/src/3-three/chunker/api/clauses.js
+++ b/src/3-three/chunker/api/clauses.js
@@ -5,7 +5,7 @@ const clauses = function (n) {
     .ifNo('@hasComma (and|or) .') //cool, and fun
     .ifNo('(#City && @hasComma) #Country') //'toronto, canada'
     .ifNo('(#WeekDay && @hasComma) #Date') //'tuesday, march 2nd'
-    .ifNo('(#Date && @hasComma) #Year') //'july 6, 1992'
+    .ifNo('(#Date+ && @hasComma) #Value') //'july 6, 1992'
     .ifNo('@hasComma (too|also)$') //at end of sentence
     .match('@hasComma')
   let found = this.splitAfter(commas)

--- a/src/3-three/chunker/api/clauses.js
+++ b/src/3-three/chunker/api/clauses.js
@@ -2,7 +2,7 @@ const clauses = function (n) {
   // an awkward way to disambiguate a comma use
   let commas = this.if('@hasComma')
     .ifNo('@hasComma @hasComma') //fun, cool...
-    .ifNo('@hasComma . .? (and|or) .') //cool, and fun
+    .ifNo('@hasComma (and|or) .') //cool, and fun
     .ifNo('(#City && @hasComma) #Country') //'toronto, canada'
     .ifNo('(#WeekDay && @hasComma) #Date') //'tuesday, march 2nd'
     .ifNo('(#Date && @hasComma) #Year') //'july 6, 1992'

--- a/tests/three/chunker/clauses.test.js
+++ b/tests/three/chunker/clauses.test.js
@@ -4,21 +4,23 @@ const here = '[three/clauses] '
 
 test('clauses - with commas', function (t) {
   let arr = [
-    // [string, number of clauses expected]
-    ['fun, cool, etc...', 1],
-    ['cool, and fun', 1],
-    ['just one clause here!', 1],
-    ['if you must, go to the basement', 2],
-    ['an apple, washed and dried', 2],
-    ['one thing, at a time. and then another, right afterwards', 4],
-    ['oh and something else, too', 1],
-    ['tuesday, march 2nd', 1],
-    ['toronto, canada', 1],
-    //['june 6, 1992', 1] // TODO fix '(#Date && @hasComma) #Year' so it gets this one right
+    // ['string', ['expected clauses', 'in an array']]
+    ['fun, cool, etc...', ['fun, cool, etc...']],
+    ['cool, and fun', ['cool, and fun']],
+    ['one, two, and three', ['one, two, and three']],
+    ['just one clause here!', ['just one clause here!']],
+    ['if you must, go to the basement', ['if you must,', 'go to the basement']],
+    ['an apple, washed and dried', ['an apple,', 'washed and dried']],
+    ['one thing, at a time. and then another, right afterwards', ['one thing,', 'at a time.', 'and then another,', 'right afterwards']],
+    ['oh and something else, too', ['oh and something else, too']],
+    ['tuesday, march 2nd', ['tuesday, march 2nd']],
+    ['toronto, canada', ['toronto, canada']],
+    //['june 6, 1992', ['june 6, 1992']] // TODO fix '(#Date && @hasComma) #Year' so it gets this one right
   ]
   arr.forEach(function (a) {
     const clauses = nlp(a[0]).clauses().out('array')
-    t.equal(clauses.length, a[1], here + a[0])
+    t.equal(clauses.length, a[1].length, here + '[number of clauses] ' + a[0])
+    t.deepEqual(clauses, a[1], here + '[clause content] ' + a[0])
   })
   t.end()
 })

--- a/tests/three/chunker/clauses.test.js
+++ b/tests/three/chunker/clauses.test.js
@@ -1,0 +1,24 @@
+import test from 'tape'
+import nlp from '../_lib.js'
+const here = '[three/clauses] '
+
+test('clauses - with commas', function (t) {
+  let arr = [
+    // [string, number of clauses expected]
+    ['fun, cool, etc...', 1],
+    ['cool, and fun', 1],
+    ['just one clause here!', 1],
+    ['if you must, go to the basement', 2],
+    ['an apple, washed and dried', 2],
+    ['one thing, at a time. and then another, right afterwards', 4],
+    ['oh and something else, too', 1],
+    ['tuesday, march 2nd', 1],
+    ['toronto, canada', 1],
+    //['june 6, 1992', 1] // TODO fix '(#Date && @hasComma) #Year' so it gets this one right
+  ]
+  arr.forEach(function (a) {
+    const clauses = nlp(a[0]).clauses().out('array')
+    t.equal(clauses.length, a[1], here + a[0])
+  })
+  t.end()
+})

--- a/tests/three/chunker/clauses.test.js
+++ b/tests/three/chunker/clauses.test.js
@@ -15,7 +15,7 @@ test('clauses - with commas', function (t) {
     ['oh and something else, too', ['oh and something else, too']],
     ['tuesday, march 2nd', ['tuesday, march 2nd']],
     ['toronto, canada', ['toronto, canada']],
-    //['june 6, 1992', ['june 6, 1992']] // TODO fix '(#Date && @hasComma) #Year' so it gets this one right
+    ['june 6, 1992', ['june 6, 1992']]
   ]
   arr.forEach(function (a) {
     const clauses = nlp(a[0]).clauses().out('array')


### PR DESCRIPTION
While I was debugging some of my post-update test failures I noticed that `clauses()` failed to split a string like "two whole ducks, necks and giblets reserved".

I wanted to try and fix it myself before bugging you with another bug report, so I added a reproducer test ("an apple, washed and dried") and a bunch of other tests for the other statements you had in `clauses.js`, and then fixed the failing ones. 

I don't know if you had other strings in mind for the expressions in question - but as they were written, they didn't succeed with the strings that the comments indicated they should support - if there's other cases that will fail due to this change we can add them to the test and figure out a suitable match expression