### PR TITLE
Add common honorifics and remove mister from abbreviations

### DIFF
--- a/data/lexicon/people/honorifics.js
+++ b/data/lexicon/people/honorifics.js
@@ -2,6 +2,8 @@
 export default [
   'admiral',
   'ayatullah',
+  'baron',
+  'baroness',
   'brigadier',
   'captain',
   'chancellor',
@@ -20,10 +22,15 @@ export default [
   'first lieutenant',
   // 'judge',
   'king',
+  'lady',
   'lieutenant',
+  'lord',
   'magistrate',
   'marshal',
   'mayor',
+  'miss',
+  'missus',
+  'mister',
   'officer',
   'pastor',
   'president',
@@ -39,5 +46,5 @@ export default [
   'sergeant',
   'sultan',
   'taoiseach',
-  'vice admiral',
+  'vice admiral'
 ]

--- a/src/1-one/tokenize/model/abbreviations/honorifics.js
+++ b/src/1-one/tokenize/model/abbreviations/honorifics.js
@@ -21,7 +21,6 @@ export default [
   'lt',
   'maj',
   'messrs',
-  'mister',
   'mlle',
   'mme',
   'mr',
@@ -42,7 +41,7 @@ export default [
   'sir',
   'sr',
   'supt',
-  'surg',
+  'surg'
   //miss
   //misses
 ]


### PR DESCRIPTION
Fixes:
In "A certain Miss Jones eats cake." the word "Miss" is not identified as an honorific because it is missing from the lexicon so added.
Mister is defined as an abbreviation but it should be an honorific: moved from abbreviations  to honorifics 
Baron, Baroness and Lord are also missing honorifics: added

Suggestions:
Took me a while to figure out I had to pack before doing build so that I could do my tests - a build_all script in package.json may help newbies like myself.




