### PR TITLE
Fix types for the dates plugin

### DIFF
--- a/plugins/dates/package.json
+++ b/plugins/dates/package.json
@@ -31,7 +31,7 @@
   "files": [
     "builds/",
     "src/",
-    "types/index.d.ts"
+    "index.d.ts"
   ],
   "eslintIgnore": [
     "builds/*.js"


### PR DESCRIPTION
This fixes missing TypeScript types for the `compromise-dates` plugin.