### PR TITLE
Added booked in rule :hammer:

### DIFF
--- a/src/2-two/postTagger/model/dates/date.js
+++ b/src/2-two/postTagger/model/dates/date.js
@@ -30,4 +30,6 @@ export default [
   { match: `#Adverb [(march|may)]`, group: 0, tag: 'Verb', reason: 'quickly-march' },
   //march quickly
   { match: `[(march|may)] #Adverb`, group: 0, tag: 'Verb', reason: 'march-quickly' },
+  // a holiday booked in May || book in May
+  { match: '(booked|book) (in|for) (march|may)', tag: 'Month', reason: 'book-in-month'},
 ]


### PR DESCRIPTION
This PR closes this [issue](https://github.com/spencermountain/compromise/issues/1008).

Another NLP tool kit could not tag this properly as a Month. So figured just hard code this in. 

I didn't think if I used ```booked in #Month``` it would set it as month. But if we can do this - switch the rule over to ```(booked|book) in #Month```.