### PR TITLE
Added Sports Complex Rule :hammer:

### DIFF
--- a/src/2-two/postTagger/model/nouns/places.js
+++ b/src/2-two/postTagger/model/nouns/places.js
@@ -20,4 +20,6 @@ export default [
   { match: 'university of #Place', tag: 'Organization', reason: 'university-of-Foo' },
   // Address 
   { match: '#Value #Noun (st|street|rd|road|crescent|cr|way|tr|terrace|avenue|ave)', tag: 'Address', reason: 'address-st' },
+  // Sports Arenas and Complexs
+  { match: '(#Place+|#Place|#ProperNoun) (memorial|athletic|community|financial)? (sportsplex|stadium|sports centre|sports field|soccer complex|soccer centre|sports complex|civic centre|centre|arena|gardens|complex|coliseum|auditorium|place|building)', tag: 'Place', reason: 'sport-complex' },
 ]


### PR DESCRIPTION
This rule is able to tag ```88 out of 198``` arenas / stadiums from [this](https://en.wikipedia.org/wiki/List_of_indoor_arenas_in_Canada) list of arenas (current arenas only tested) ie - 76%. 

Which .places() can only get - 6.25% & .organizations comes in at 39.27%

Build & tests passing: [here](https://github.com/MarketingPip/compromise/actions/runs/6193873606)

Here is the test:

```js
let list = [
    "Bell Centre",
    "Rogers Place",
    "Canadian Tire Centre",
    "Videotron Centre",
    "Scotiabank Arena",
    "Rogers Arena",
    "Scotiabank Saddledome",
    "FirstOntario Centre",
    "Pacific Coliseum",
    "Canada Life Centre",
    "SaskTel Centre",
    "Scotiabank Centre",
    "TD Place Arena",
    "Coca-Cola Coliseum",
    "Budweiser Gardens",
    "Place Bell",
    "Save-On-Foods Memorial Centre",
    "Avenir Centre",
    "Halifax Forum",
    "Abbotsford Centre",
    "WFCU Centre",
    "Prospera Place",
    "Peavey Mart Centrium",
    "Kitchener Memorial Auditorium",
    "Tribute Communities Centre",
    "TD Station",
    "Moncton Coliseum",
    "Brandt Centre",
    "Enmax Centre",
    "Mary Brown's Centre",
    "CN Centre",
    "Paramount Fine Foods Centre",
    "Canalta Centre",
    "Doug Mitchell Thunderbird Sports Centre",
    "Leon's Centre",
    "Centre 200",
    "Sleeman Centre",
    "GFL Memorial Gardens",
    "South Okanagan Events Centre",
    "Meridian Centre",
    "Sandman Centre",
    "Chilliwack Coliseum",
    "Western Financial Place",
    "Consolidated Credit Union Place",
    "Progressive Auto Sales Arena",
    "Kal Tire Place",
    "Universiade Pavilion (Butterdome)",
    "Sadlon Arena",
    "Langley Events Centre",
    "Centre Bionest de Shawinigan",
    "Westman Place at Keystone Centre",
    "Sudbury Community Arena",
    "Colisée Financière Sun Life",
    "Ed Lumley Arena",
    "CAA Centre",
    "Mosaic Place",
    "Maurice Richard Arena",
    "Centre Georges-Vézina",
    "Fort William Gardens",
    "Edmonton Expo Centre",
    "Ovintiv Events Centre",
    "CAA Arena",
    "Colisée Vidéotron",
    "K.C. Irving Regional Centre",
    "Peterborough Memorial Centre",
    "J.D. McArthur Arena",
    "Aitken Centre",
    "Sun Life Financial Arena",
    "Varsity Arena",
    "Verdun Auditorium",
    "Slush Puppie Centre",
    "North Bay Memorial Gardens",
    "Eastlink Centre",
    "Robert Guertin Centre",
    "Centre Marcel Dionne",
    "WinSport Arena",
    "Markin-MacPhail Centre",
    "Ray Twinney Complex",
    "Palais des Sports",
    "Thompson Arena",
    "Rath Eastlink Community Centre",
    "Art Hauser Centre",
    "Centre Air Creebec",
    "Colisée de Laval",
    "Kahnawake Sports Complex",
    "Colisée de Trois-Rivières",
    "Memorial Civic Center",
    "Zatzman Sportsplex",
    "Aréna Iamgold",
    "Earl Armstrong Arena",
    "Queen's Park Arena",
    "Colisée Desjardins",
    "Kingston Memorial Centre",
    "Centre d'Excellence Sports Rousseau",
    "Credit Union iPlex",
    "Revolution Place",
    "Palais des Sports de Saguenay",
    "Jack Gatecliff Arena",
    "Pepsi Centre",
    "Centre Henry-Leonard",
    "Colisée Cardin",
    "Centre Premier Tech",
    "Investors Group Athletic Centre",
    "Frank Crane Arena",
    "Steve Yzerman Arena",
    "Ken Bracko Arena (Max Bell Centre)",
    "Brantford Civic Centre",
    "Sobeys Arena",
    "William Allman Memorial Arena",
    "Miramichi Civic Centre",
    "Acadia Arena",
    "Mattamy Athletic Centre",
    "The Q Centre",
    "Colisée Isabelle-Brasseur",
    "Selkirk Recreation Complex",
    "Clare Drake Arena",
    "Centre Pierre Charbonneau",
    "Colisée Jean Béliveau",
    "St. Thomas-Elgin Memorial Centre",
    "West Central Events Centre",
    "Arctic Winter Games Arena",
    "Centre Mario Gosselin",
    "Amherst Stadium",
    "Dave Andreychuk Mountain Arena",
    "North Battleford Civic Centre",
    "Woodstock District Community Complex",
    "Centre Sportif Lacroix-Dutil",
    "Chatham Memorial Arena",
    "Tamitik Arena",
    "Centre sportif Léonard-Grondin",
    "Centerfire Place",
    "Hants Exhibition Arena",
    "Markham Centennial Centre",
    "Merlis Belsher Place",
    "Centennial Regional Arena",
    "Antigonish Arena",
    "Pembroke Memorial Centre",
    "Eastlink Events Centre",
    "Charles V. Keating Millennium Centre",
    "Centre Étienne Desmarteau",
    "Poirier Sport & Leisure Complex",
    "Shaw Centre",
    "Cominco Arena",
    "Cowichan Valley Arena",
    "Aréna Marcel-Bédard",
    "Bill Copeland Sports Centre",
    "Father David Bauer Olympic Arena",
    "Jim Peplinski Arena",
    "Whitney Forum",
    "Winkler Arena",
    "Port Hawkesbury Civic Centre",
    "Stride Place",
    "McIntyre Community Building",
    "Elgar Peterson Arena",
    "Weyerhaeuser Arena",
    "Drumheller Memorial Arena",
    "Rolling Mix Concrete Arena",
    "R.J. Lalonde Arena",
    "Bill Hunter Arena",
    "Brockville Memorial Civic Centre",
    "Credit Union Place",
    "Mariners Centre",
    "Crescent Point Place",
    "Centennial Civic Centre",
    "Royal LePage Place",
    "Colchester Legion Stadium",
    "McConnell Arena",
    "St. Michael's College School Arena",
    "T.G. Smith Centre",
    "Jubilee Recreation Centre",
    "Takhini Arena",
    "Horizon Credit Union Centre",
    "Arena de Lachine",
    "Kinsmen Recreation Complex",
    "Grant-Harvey Centre",
    "Farrell Agencies Arena",
    "Eagle Builders Centre",
    "Wayne Fleming Arena (Max Bell Centre)",
    "MTS Iceplex",
    "Grant Fuhr Arena",
    "Joe Byrne Memorial Stadium",
    "South Surrey Arena",
    "Canlan Ice Sports – York",
    "Tundra Oil & Gas Place",
    "Yellowhead Centre",
    "Nelson & District Community Complex",
    "Legends Centre",
    "Galt Arena Gardens",
    "Gordon Lathlin Memorial Centre",
    "Steele Community Centre",
    "Garcelon Civic Centre",
    "MSA Arena",
    "Hap Parker Arena",
    "Kings Mutual Century Centre",
    "Ford Performance Centre",
    "Nicola Valley Memorial Arena",
    "Downtown Community Arena",
    "Wynyard Memorial Arena"
]

let count = 0
let missing = []
list.forEach(str => {
  let doc = nlp(str)
  if (!doc.match("(#Place+|#ProperNoun) (memorial|athletic|community|financial)? (sportsplex|stadium|sports centre|sports field|soccer complex|soccer centre|sports complex|civic centre|centre|arena|gardens|complex|coliseum|auditorium|place|building)").found) {
    count += 1
    missing.push(str)// 
  }
})
console.log(count, list.length)
console.log(JSON.stringify(missing, null, 2))//
```