### PR TITLE
fix Compromise and NLTK link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -856,7 +856,7 @@ nlp.extend({
 ##### Comparisons
 
 - [Compromise and Spacy](https://observablehq.com/@spencermountain/compromise-and-spacy)
-- [Compromise and NLTK](https://observablehq.com/@spencermountain/compromise-and-NLTK)
+- [Compromise and NLTK](https://observablehq.com/@spencermountain/compromise-and-nltk)
 
 <!-- spacer -->
 <div align="center">


### PR DESCRIPTION
all caps https://observablehq.com/@spencermountain/compromise-and-NLTK link didn't work
<img width="1442" alt="Screenshot 2023-11-25 at 2 53 32 AM" src="https://github.com/spencermountain/compromise/assets/31113245/1bc9cc3b-4572-4304-a9c5-7d8d9361aea8">

lowercase https://observablehq.com/@spencermountain/compromise-and-nltk works