### PR TITLE
Fix for some switch lock-ins for common terms

### DIFF
--- a/src/2-two/preTagger/compute/tagger/3rd-pass/06-switches.js
+++ b/src/2-two/preTagger/compute/tagger/3rd-pass/06-switches.js
@@ -13,7 +13,7 @@ const checkWord = (term, obj) => {
     found = obj[str]
   }
   if (found && env.DEBUG_TAGS) {
-    console.log(`\n  \x1b[2m\x1b[3m     ↓ - '${str}' \x1b[0m`)//eslint-disable-line
+    console.log(`\n  \x1b[2m\x1b[3m     ↓ - '${str}' \x1b[0m`) //eslint-disable-line
   }
   return found
 }
@@ -30,7 +30,7 @@ const checkTag = (term, obj = {}, tagSet) => {
   })
   let found = tags.find(tag => obj[tag])
   if (found && env.DEBUG_TAGS) {
-    console.log(`  \x1b[2m\x1b[3m      ↓ - '${term.normal || term.implicit}' (#${found})  \x1b[0m`)//eslint-disable-line
+    console.log(`  \x1b[2m\x1b[3m      ↓ - '${term.normal || term.implicit}' (#${found})  \x1b[0m`) //eslint-disable-line
   }
   found = obj[found]
   return found
@@ -40,13 +40,14 @@ const pickTag = function (terms, i, clues, model) {
   if (!clues) {
     return null
   }
+  const beforeIndex = terms[i - 1]?.text !== 'also' ? i - 1 : Math.max(0, i - 2)
   const tagSet = model.one.tagSet
   // look -> right word, first
   let tag = checkWord(terms[i + 1], clues.afterWords)
   // look <- left word, second
-  tag = tag || checkWord(terms[i - 1], clues.beforeWords)
-  // look <- left tag 
-  tag = tag || checkTag(terms[i - 1], clues.beforeTags, tagSet)
+  tag = tag || checkWord(terms[beforeIndex], clues.beforeWords)
+  // look <- left tag
+  tag = tag || checkTag(terms[beforeIndex], clues.beforeTags, tagSet)
   // look -> right tag
   tag = tag || checkTag(terms[i + 1], clues.afterTags, tagSet)
   // console.log(clues)
@@ -82,7 +83,7 @@ const doSwitches = function (terms, i, world) {
       // add plural/singular etc.
       fillTags(terms, i, model)
     } else if (env.DEBUG_TAGS) {
-      console.log(`\n -> X  - '${str}'  : (${form})  `)//eslint-disable-line
+      console.log(`\n -> X  - '${str}'  : (${form})  `) //eslint-disable-line
     }
   }
 }

--- a/src/2-two/preTagger/model/clues/_adj.js
+++ b/src/2-two/preTagger/model/clues/_adj.js
@@ -61,6 +61,6 @@ export default {
     also: jj, //insulting too
     or: jj, //insulting or
     enough: jj, //cool enough
-    about: jj, //cool about
+    //about: jj, //cool about
   },
 }

--- a/src/2-two/preTagger/model/clues/adj-past.js
+++ b/src/2-two/preTagger/model/clues/adj-past.js
@@ -17,22 +17,22 @@ const adjPast = {
     Pronoun: past, //hooked me
     Determiner: past, //hooked the
     Adverb: past, //cooked perfectly
-    Comparative: past,//closed higher
-    Date: past,// alleged thursday
-    Gerund: past,//left dancing
+    Comparative: past, //closed higher
+    Date: past, // alleged thursday
+    Gerund: past, //left dancing
   },
   beforeWords: {
-    be: past,//be hooked vs be embarrassed
-    who: past,//who lost
-    get: 'Adjective',//get charged
+    be: past, //be hooked vs be embarrassed
+    who: past, //who lost
+    get: 'Adjective', //get charged
     had: past,
     has: past,
     have: past,
     been: past,
-    it: past,//it intoxicated him
-    as: past,//as requested
-    for: 'Adjective',//for discounted items
-    more: 'Adjective',//more broken promises
+    it: past, //it intoxicated him
+    as: past, //as requested
+    for: 'Adjective', //for discounted items
+    more: 'Adjective', //more broken promises
   },
   afterWords: {
     by: past, //damaged by
@@ -49,16 +49,17 @@ const adjPast = {
     as: past, //known as
     on: past, //focused on
     at: past, //recorded at
-    between: past,//settled between
-    to: past,//dedicated to
-    into: past,//pumped into
-    us: past,//charged us
-    them: past,//charged us
-    his: past,//shared his
-    her: past,//
-    their: past,//
-    our: past,//
-    me: past,//
+    between: past, //settled between
+    to: past, //dedicated to
+    into: past, //pumped into
+    us: past, //charged us
+    them: past, //charged us
+    his: past, //shared his
+    her: past, //
+    their: past, //
+    our: past, //
+    me: past, //
+    about: 'Adjective',
   },
 }
 

--- a/tests/two/variables/past-adj.test.js
+++ b/tests/two/variables/past-adj.test.js
@@ -3,7 +3,6 @@ import nlp from '../_lib.js'
 const here = '[two/past-adj] '
 
 let arr = [
-
   // == adjectives ==
   [`'cool'`, '#Adjective'],
   ['great', '#Adjective'],
@@ -156,6 +155,18 @@ let arr = [
   // ['it was fixed', '#Noun #Copula #PastTense'],
   ['it will be boxed', '#Noun #Verb #Verb #PastTense'],
   // ['i am gutted', '#Noun #PastTense #Adjective'],
+  // [
+  //   'She felt abandoned about the sudden change in plans',
+  //   '#Pronoun #PastTense #Adjective #Preposition #Determiner #Adjective #Noun #Preoposition #Noun',
+  // ],
+  [
+    'The puzzled detective was bewildered about the abandoned clues.',
+    '#Determiner #Adjective #Noun #Copula #Adjective #Preposition #Determiner #Adjective #Noun',
+  ],
+  [
+    "He was amazed about the abandoned building's mysterious past.",
+    '#Pronoun #Copula #Adjective #Preposition #Determiner #Adjective #Possessive #Adjective #Noun',
+  ],
 ]
 test('match:', function (t) {
   arr.forEach(function (a) {

--- a/tests/two/variables/past-adj.test.js
+++ b/tests/two/variables/past-adj.test.js
@@ -167,6 +167,8 @@ let arr = [
     "He was amazed about the abandoned building's mysterious past.",
     '#Pronoun #Copula #Adjective #Preposition #Determiner #Adjective #Possessive #Adjective #Noun',
   ],
+  ['He also developed software.', '#Pronoun #Adverb #Verb #Noun'],
+  ['Cheese is also aged', '#Noun #Copula #Adverb #Adjective'],
 ]
 test('match:', function (t) {
   arr.forEach(function (a) {


### PR DESCRIPTION
# About
(Part of #1074)
- John's talks about Georgia

The word "about" no longer is an afterWords switch for all switches utilizing _adj. It is still used for adj-past switches though.

# Also
Fixes #1070 
- He also developed [should be PastTense, not adjective] software.
- Cheese is also aged [should be adjective]

If "also" is the term previous in the sentence, use the next most previous term (if one exists), for the tests.

I'm sure there are edge cases being missed and other "lock-in" terms which may be causing issues. But I wanted to get this in before you publish the next release to take care of these more simple issues.

How does this look? I'm worried this might break certain sentences or phrases that we aren't testing for.