### PR TITLE
ci: bump github actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,21 +12,14 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: use node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-npm-${{ matrix.node-version }}-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm-${{ matrix.node-version }}-
-            ${{ runner.os }}-npm-
+          cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: install
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,17 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '16'
-
-      - uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          cache: npm
+          cache-dependency-path: package-lock.json
 
       - run: npm ci
       - run: npm i -g c8 codecov

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,20 +14,13 @@ jobs:
     # delegate to the build- and-test workflow, but I haven't found a way to do
     # that yet.
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 16.x
-
-      - name: cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-npm-10.x-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm-10.x-
-            ${{ runner.os }}-npm-
+          cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: install
         run: |


### PR DESCRIPTION
This PR bumps GitHub Actions to their latest available versions.
- Changelog for `actions/checkout` can be [found here](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- Releases for `actions/setup-node` can be [found here](https://github.com/actions/setup-node/releases)

This PR also removes `actions/cache` and uses the caching options from `actions/setup-node`, which functions the same.