### PR TITLE
ci(release): update workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     # Note that these steps are *identical* to build-and-test (with the caveat
     # that build-and-test uses several versions of Node, and Release only uses
@@ -15,12 +18,13 @@ jobs:
     # that yet.
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
           node-version: 16.x
           cache: npm
-          cache-dependency-path: package-lock.json
 
       - name: install
         run: |
@@ -51,6 +55,6 @@ jobs:
       - name: publish
         run: |
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
-          npm publish
+          npm publish --access public --provenance
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR:

-   Removes Git credentials/SSH keys after checkout as a security precaution by setting `persist-credentials` to false. They are not used after the initial checkout, and this stops them from accidentally leaking through a script
-   Declares the minimum permissions for the workflows to run at the job level, following principle of least privilege; see [related GitHub security post](https://securitylab.github.com/research/github-actions-building-blocks/)
-   Removes the `cache-dependency-path` param from the `actions/setup-node` action, as if `cache` is declared then it will use the default path anyway
-   Updates `npm publish` script to [publish with provenance](https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions) to provide assurance that published package was generated from this repo