### PR TITLE
chore: export view types

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,15 @@
       "import": "./src/three.js",
       "require": "./builds/three/compromise-three.cjs",
       "types": "./types/three.d.ts"
+    },
+    "./view/one": {
+      "types": "./types/view/one.d.ts"
+    },
+    "./view/two": {
+      "types": "./types/view/two.d.ts"
+    },
+    "./view/three": {
+      "types": "./types/view/three.d.ts"
     }
   },
   "typesVersions": {


### PR DESCRIPTION
I was previously able to declare a variable's type in VS Code using the following:
```js
/** @type {import('compromise/types/view/three').default} */`
const test = nlp.view;

console.log(test.sentences());
```

This would allow Intellisense to kick in, so if i hovered over `test.sentences()` i'd get the following:
![image](https://github.com/spencermountain/compromise/assets/43814140/fcdbf66b-5855-4a6c-81fc-a58d4c0e1c7e)


However it seems the latest minor version of TypeScript which shipped with VS Code has removed that.
This PR updates package.json to explicitly export the view types, so that the type can continue to be declared like so:
```js
/** @type {import('compromise/view/three').default} */
const test = nlp.view
```