### PR TITLE
chore(package): export misc types

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
       "require": "./builds/three/compromise-three.cjs",
       "types": "./types/three.d.ts"
     },
+    "./misc": {
+      "types": "./types/misc.d.ts"
+    },
     "./view/one": {
       "types": "./types/view/one.d.ts"
     },


### PR DESCRIPTION
Forgot to include this in #1104, the `Net` type in the misc types is handy!