### PR TITLE
fix: TypeScript resolution should now work across bundlers

### DIFF
--- a/one/package.json
+++ b/one/package.json
@@ -1,0 +1,25 @@
+{
+	"name": "compromise-one",
+	"version": "14.14.3",
+	"description": "",
+	"type": "module",
+	"module": "./../src/one.js",
+	"main": "./../src/one.js",
+	"types": "./../types/one.d.ts",
+	"exports": {
+		"./package.json": "./package.json",
+		".": {
+			"import": {
+				"types": "./../types/one/one.d.ts",
+				"default": "./../src/one.js"
+			},
+			"require": {
+				"types": "./../types/one.d.cts",
+				"default": "./../builds/one/compromise-one.cjs"
+			}
+		}
+	},
+	"author": "Spencer Kelly <spencermountain@gmail.com> (http://spencermounta.in)",
+	"license": "MIT",
+	"sideEffects": true
+}

--- a/package.json
+++ b/package.json
@@ -11,29 +11,29 @@
   "types": "./types/three.d.ts",
   "exports": {
     ".": {
+      "types": "./types/three.d.ts",
       "import": "./src/three.js",
-      "require": "./builds/three/compromise-three.cjs",
-      "types": "./types/three.d.ts"
+      "default": "./builds/three/compromise-three.cjs"
     },
     "./tokenize": {
+      "types": "./types/one.d.ts",
       "import": "./src/one.js",
-      "require": "./builds/one/compromise-one.cjs",
-      "types": "./types/one.d.ts"
+      "default": "./builds/one/compromise-one.cjs"
     },
     "./one": {
+      "types": "./types/one.d.ts",
       "import": "./src/one.js",
-      "require": "./builds/one/compromise-one.cjs",
-      "types": "./types/one.d.ts"
+      "default": "./builds/one/compromise-one.cjs"
     },
     "./two": {
+      "types": "./types/two.d.ts",
       "import": "./src/two.js",
-      "require": "./builds/two/compromise-two.cjs",
-      "types": "./types/two.d.ts"
+      "default": "./builds/two/compromise-two.cjs"
     },
     "./three": {
+      "types": "./types/three.d.ts",
       "import": "./src/three.js",
-      "require": "./builds/three/compromise-three.cjs",
-      "types": "./types/three.d.ts"
+      "default": "./builds/three/compromise-three.cjs"
     },
     "./misc": {
       "types": "./types/misc.d.ts"

--- a/package.json
+++ b/package.json
@@ -11,29 +11,54 @@
   "types": "./types/three.d.ts",
   "exports": {
     ".": {
-      "types": "./types/three.d.ts",
-      "import": "./src/three.js",
-      "default": "./builds/three/compromise-three.cjs"
+      "import": {
+        "types": "./types/three.d.ts",
+        "default": "./src/three.js"
+      },
+      "require": {
+        "types": "./types/three.d.cts",
+        "default": "./builds/three/compromise-three.cjs"
+      }
     },
     "./tokenize": {
-      "types": "./types/one.d.ts",
-      "import": "./src/one.js",
-      "default": "./builds/one/compromise-one.cjs"
+      "import": {
+        "types": "./types/one.d.ts",
+        "default": "./src/one.js"
+      },
+      "require": {
+        "types": "./types/one.d.cts",
+        "default": "./builds/one/compromise-one.cjs"
+      }
     },
     "./one": {
-      "types": "./types/one.d.ts",
-      "import": "./src/one.js",
-      "default": "./builds/one/compromise-one.cjs"
+      "import": {
+        "types": "./types/one.d.ts",
+        "default": "./src/one.js"
+      },
+      "require": {
+        "types": "./types/one.d.cts",
+        "default": "./builds/one/compromise-one.cjs"
+      }
     },
     "./two": {
-      "types": "./types/two.d.ts",
-      "import": "./src/two.js",
-      "default": "./builds/two/compromise-two.cjs"
+      "import": {
+        "types": "./types/two.d.ts",
+        "default": "./src/two.js"
+      },
+      "require": {
+        "types": "./types/two.d.cts",
+        "default": "./builds/two/compromise-two.cjs"
+      }
     },
     "./three": {
-      "types": "./types/three.d.ts",
-      "import": "./src/three.js",
-      "default": "./builds/three/compromise-three.cjs"
+      "import": {
+        "types": "./types/three.d.ts",
+        "default": "./src/three.js"
+      },
+      "require": {
+        "types": "./types/three.d.cts",
+        "default": "./builds/three/compromise-three.cjs"
+      }
     },
     "./misc": {
       "types": "./types/misc.d.ts"
@@ -46,19 +71,6 @@
     },
     "./view/three": {
       "types": "./types/view/three.d.ts"
-    }
-  },
-  "typesVersions": {
-    "*": {
-      "one": [
-        "./types/one.d.ts"
-      ],
-      "two": [
-        "./types/two.d.ts"
-      ],
-      "three": [
-        "./types/three.d.ts"
-      ]
     }
   },
   "repository": {
@@ -94,7 +106,11 @@
   "files": [
     "builds/",
     "types/",
-    "src/"
+    "src/",
+    "tokenize/",
+    "one/",
+    "two/",
+    "three/"
   ],
   "keywords": [
     "nlp"

--- a/package.json
+++ b/package.json
@@ -59,18 +59,6 @@
         "types": "./types/three.d.cts",
         "default": "./builds/three/compromise-three.cjs"
       }
-    },
-    "./misc": {
-      "types": "./types/misc.d.ts"
-    },
-    "./view/one": {
-      "types": "./types/view/one.d.ts"
-    },
-    "./view/two": {
-      "types": "./types/view/two.d.ts"
-    },
-    "./view/three": {
-      "types": "./types/view/three.d.ts"
     }
   },
   "repository": {

--- a/three/package.json
+++ b/three/package.json
@@ -1,0 +1,25 @@
+{
+	"name": "compromise-three",
+	"version": "14.14.3",
+	"description": "",
+	"type": "module",
+	"module": "./../src/three.js",
+	"main": "./../src/three.js",
+	"types": "./../types/three.d.ts",
+	"exports": {
+		"./package.json": "./package.json",
+		".": {
+			"import": {
+				"types": "./../types/three/three.d.ts",
+				"default": "./../src/three.js"
+			},
+			"require": {
+				"types": "./../types/three.d.cts",
+				"default": "./../builds/three/compromise-three.cjs"
+			}
+		}
+	},
+	"author": "Spencer Kelly <spencermountain@gmail.com> (http://spencermounta.in)",
+	"license": "MIT",
+	"sideEffects": true
+}

--- a/tokenize/package.json
+++ b/tokenize/package.json
@@ -1,0 +1,25 @@
+{
+	"name": "compromise-tokenize",
+	"version": "14.14.3",
+	"description": "",
+	"type": "module",
+	"module": "./../src/one.js",
+	"main": "./../src/one.js",
+	"types": "./../types/one.d.ts",
+	"exports": {
+		"./package.json": "./package.json",
+		".": {
+			"import": {
+				"types": "./../types/one/one.d.ts",
+				"default": "./../src/one.js"
+			},
+			"require": {
+				"types": "./../types/one.d.cts",
+				"default": "./../builds/one/compromise-one.cjs"
+			}
+		}
+	},
+	"author": "Spencer Kelly <spencermountain@gmail.com> (http://spencermounta.in)",
+	"license": "MIT",
+	"sideEffects": true
+}

--- a/two/package.json
+++ b/two/package.json
@@ -1,0 +1,25 @@
+{
+	"name": "compromise-two",
+	"version": "14.14.3",
+	"description": "",
+	"type": "module",
+	"module": "./../src/two.js",
+	"main": "./../src/two.js",
+	"types": "./../types/two.d.ts",
+	"exports": {
+		"./package.json": "./package.json",
+		".": {
+			"import": {
+				"types": "./../types/two/two.d.ts",
+				"default": "./../src/two.js"
+			},
+			"require": {
+				"types": "./../types/two.d.cts",
+				"default": "./../builds/two/compromise-two.cjs"
+			}
+		}
+	},
+	"author": "Spencer Kelly <spencermountain@gmail.com> (http://spencermounta.in)",
+	"license": "MIT",
+	"sideEffects": true
+}

--- a/types/one.d.cts
+++ b/types/one.d.cts
@@ -1,0 +1,4 @@
+import nlp from "./one.d";
+
+export = nlp
+

--- a/types/three.d.cts
+++ b/types/three.d.cts
@@ -1,0 +1,4 @@
+import nlp from "./three.d";
+
+export = nlp
+

--- a/types/two.d.cts
+++ b/types/two.d.cts
@@ -1,0 +1,4 @@
+import nlp from "./two.d";
+
+export = nlp
+

--- a/types/view/one.d.cts
+++ b/types/view/one.d.cts
@@ -1,0 +1,4 @@
+import View from "./one.d";
+
+export = View
+

--- a/types/view/three.d.cts
+++ b/types/view/three.d.cts
@@ -1,0 +1,4 @@
+import Three from "./three.d";
+
+export = Three
+

--- a/types/view/two.d.cts
+++ b/types/view/two.d.cts
@@ -1,0 +1,4 @@
+import Two from "./two.d";
+
+export = Two
+


### PR DESCRIPTION
This PR fixes #1164 by:

- Fixing fallback cases
- Adding `node10` (think Webpack 4 and older node) resolution via `{root}/one/package.json` files
- Creating CJS-specific `.d.cts` types so TypeScript doesn't incorrectly warn of `default` usage when doing a `require`
- Removing unused (AFAICT) type exports like `./misc` and `./views`

This should not be a breaking change for existing users, but will likely fix **many** reported problems in CJS (and even some ESM) usage of this library

# Before

Using "AreTheTypesWrong" CLI:

![image](https://github.com/user-attachments/assets/caf88b59-d75c-49e3-9fa2-ee979e6bb11b)

# After

Using the same CLI:

![image](https://github.com/user-attachments/assets/49fc4964-d6a4-4b73-ba4a-65da42060fdc)
