### PR TITLE
Revert "chore: remove unused package exports"

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,18 @@
         "types": "./types/three.d.cts",
         "default": "./builds/three/compromise-three.cjs"
       }
+    },
+    "./misc": {
+      "types": "./types/misc.d.ts"
+    },
+    "./view/one": {
+      "types": "./types/view/one.d.ts"
+    },
+    "./view/two": {
+      "types": "./types/view/two.d.ts"
+    },
+    "./view/three": {
+      "types": "./types/view/three.d.ts"
     }
   },
   "repository": {


### PR DESCRIPTION
This reverts commit e8bb120e85cf4a3b92826d23e680229a4d044678.

The aforementioned commit removed the ability to access some types from consumer. Missing types being Term, Lexicon, Plugin, View and some more

There are some evil tricks to access those types nonetheless, but a clean way to do that would be appreciated.

This pull enable again export of submodules `compromise/misc` `compromise/view/one` `compromise/view/two` `compromise/view/three`