### PR TITLE
ci: pin github actions to commit-hash

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,15 +14,16 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
       - name: use node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
+          check-latest: true
 
       - name: install
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,14 +13,15 @@ jobs:
       contents: read
   
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: '20'
           cache: npm
+          check-latest: true
 
       - run: npm ci
       - run: npm i -g c8 codecov

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,14 +17,15 @@ jobs:
     # delegate to the build- and-test workflow, but I haven't found a way to do
     # that yet.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: 20.x
           cache: npm
+          check-latest: true
 
       - name: install
         run: |


### PR DESCRIPTION
Follow the recent compromise of [tj-actions/changed-files](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised), this PR pins GitHub actions to specific commit hashes to ensure a known version of each action is used, mitigating the risk of a supply chain attack through malicious updates.

[See related blog post by rafaelgss about pinning to the commit-hash](https://blog.rafaelgss.dev/why-you-should-pin-actions-by-commit-hash).


At the same time, i've also set  `check-latest` to true, so that the `actions/setup-node` will check it is using the latest minor or hotfix Node version and use that instead of its cached version, this stops an issue like with 22.5.0 that introduced a regression and actions were still using that instead of 22.5.1.