### PR TITLE
Improve typescript cjs support for dates

### DIFF
--- a/plugins/dates/index.d.cts
+++ b/plugins/dates/index.d.cts
@@ -1,0 +1,3 @@
+import dates from './index.d';
+
+export = dates

--- a/plugins/dates/package.json
+++ b/plugins/dates/package.json
@@ -11,9 +11,14 @@
   "types": "./index.d.ts",
   "exports": {
     ".": {
-      "import": "./src/plugin.js",
-      "require": "./builds/compromise-dates.cjs",
-      "types": "./index.d.ts"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./src/plugin.js"
+      },
+      "require": {
+        "types": "./index.d.cts",
+        "default": "./builds/compromise-dates.cjs"
+      }
     }
   },
   "repository": {


### PR DESCRIPTION
The `compromise-dates` plugin was building a commonjs package, but the types weren't properly exported in a way that TypeScript was able to import them.

By providing an `index.d.cts` file and updating the `exports` property of the `package.json` for this plugin we're able to now properly import `compromise-dates` in a commonjs TypeScript project.