### PR TITLE
perf(posttagger): remove unused cache

### DIFF
--- a/src/2-two/postTagger/compute/index.js
+++ b/src/2-two/postTagger/compute/index.js
@@ -12,7 +12,6 @@ const postTagger = function (view) {
     return [t.index[0], t.index[1], t.index[1] + terms.length]
   })
   const m = view.update(ptrs)
-  m.cache()
   m.sweep(net)
   view.uncache()
   view.unfreeze()


### PR DESCRIPTION
Removed the `m.cache()` call as `m.sweep()` on the line following [already builds its own per-clause cache](https://github.com/spencermountain/compromise/blob/592ba645400eb5d54e0d0ea52dde4f729a7c5e26/src/1-one/sweep/methods/sweep/index.js#L19) and never reads `m._cache`, so  the result was discarded unused.

This saves one full-document pass (~15ms and ~3MB of garbage per 300KB parse).
Because `postTagger` also re-runs once per verb during conjugation, this change removed a large amount of wasted work from `verbs().toPastTense()` on a complex 300KB document when tested locally.