### PR TITLE
perf(posttagger): only re-tag the term ranges the view points at

### DIFF
--- a/src/2-two/postTagger/compute/index.js
+++ b/src/2-two/postTagger/compute/index.js
@@ -6,7 +6,7 @@ const postTagger = function (view) {
   const { model, methods } = world
   net = net || methods.one.buildNet(model.two.matches, world)
   // perform these matches on a comma-seperated document
-  const document = methods.two.quickSplit(view.document)
+  const document = methods.two.quickSplit(view.docs)
   const ptrs = document.map(terms => {
     const t = terms[0]
     return [t.index[0], t.index[1], t.index[1] + terms.length]


### PR DESCRIPTION
`postTagger` runs over the entire document using `view.document` even when called on a smaller view, unlike [freeze](https://github.com/spencermountain/compromise/blob/592ba645400eb5d54e0d0ea52dde4f729a7c5e26/src/1-one/freeze/compute.js#L8), [lexicon](https://github.com/spencermountain/compromise/blob/5ce88d07c109f4b69c291ce11830c3d2812552b3/src/1-one/lexicon/compute/index.js#L9), and other functions, that use `view.docs`.

The [verb conjugators](https://github.com/spencermountain/compromise/tree/master/src/3-three/verbs/api/conjugate) re-tag after every change, so each conjugated verb re-ran the post-tagger over the entire document.
This change makes calling `doc.verbs().toPastTense()` on a large 300KB text file go from minutes to under a second.