### PR TITLE
fix: preserve non-breaking spaces when tokenizing

### DIFF
--- a/src/1-one/tokenize/methods/01-sentences/index.js
+++ b/src/1-one/tokenize/methods/01-sentences/index.js
@@ -16,8 +16,6 @@ const splitSentences = function (text, world) {
   if (!text || typeof text !== 'string' || hasSomething.test(text) === false) {
     return []
   }
-  // cleanup unicode-spaces
-  text = text.replace(/\xa0/g, ' ')
   // First do a greedy-split..
   const splits = simpleSplit(text)
   // Filter-out the crap ones

--- a/tests/one/misc/whitespace.test.js
+++ b/tests/one/misc/whitespace.test.js
@@ -33,3 +33,44 @@ test('pre/post concat', function (t) {
   t.equal(doc.text(), `Getting ready for whacking day?  What's whacking day?`)
   t.end()
 })
+
+test('preserve non-breaking spaces', function (t) {
+  const inputs = [
+    'one\u00a0two\u00a0three.',
+    'One sentence.\u00a0Next sentence.',
+    '\u00a0one\u00a0two\u00a0',
+    'I .\u00a0.\u00a0. maybe.',
+    '「はい。」\u00a0「いいえ。」',
+    'one\ttwo three.',
+  ]
+  inputs.forEach(str => {
+    const doc = nlp(str)
+    const ascii = nlp(str.replace(/\u00a0/g, ' '))
+    t.equal(doc.text(), str, here + 'preserve original whitespace')
+    t.deepEqual(
+      doc.out('array').map(s => s.replace(/\u00a0/g, ' ')),
+      ascii.out('array'),
+      here + 'same sentence boundaries'
+    )
+  })
+  t.end()
+})
+
+test('non-breaking space terms and offsets', function (t) {
+  const str = '\u00a0One\u00a0two.\u00a0Three\u00a0four.\u00a0'
+  const doc = nlp(str)
+  const json = doc.json({ offset: true })
+  t.deepEqual(json.map(s => s.text), ['One\u00a0two.', 'Three\u00a0four.'], here + 'sentence text')
+  t.deepEqual(json.map(s => s.offset), [
+    { index: 0, start: 1, length: 8 },
+    { index: 2, start: 10, length: 11 },
+  ], here + 'sentence offsets')
+  t.deepEqual(json.map(s => s.terms.map(term => term.index)), [
+    [[0, 0], [0, 1]],
+    [[1, 0], [1, 1]],
+  ], here + 'term indices')
+  t.equal(doc.match('three four').text(), 'Three\u00a0four.', here + 'match across non-breaking space')
+  t.equal(nlp('old\u00a0in').text('normal'), 'old in', here + 'explicit normalized output')
+  t.equal(nlp('Miami, FL\u00a033178').has('fl 33178'), true, here + 'split non-breaking space')
+  t.end()
+})


### PR DESCRIPTION
Splitting sentences currently replaces non-breaking spaces with regular spaces, so reading the document back changes the original text. For example, `nlp('one\u00a0two').text()` returns `'one two'`.

Remove that replacement and let the existing whitespace tokenizer preserve the original characters. Add regression coverage for repeated and surrounding non-breaking spaces, sentence boundaries, punctuation, term matching, offsets, and explicit normalized output.

Closes #1142.

Validation:

- macOS, Node 26.7.0 / pnpm 11.5.0; Linux, Node 24.20.0 / pnpm 11.5.0.
- `pnpm lint`, `pnpm test`, `pnpm test:plugins`, `pnpm build`, `pnpm plugins:build`, and `pnpm testb` passed on both platforms: 13,522 source assertions, 6,615 plugin assertions, 8 smoke assertions, and 13,522 built assertions.
- The regression file fails on the original source and passes with the change; Linux focused validation passed 27 assertions.
- One Linux benchmark comparison measured 3.9353 runs/sec for the base and 3.58 for the change (8.93% slower), within the existing 10% threshold. This is a single measurement, not a claim of performance parity.

Generated bundles were checked but are not included in this change. Existing build size warnings remain; each rebuilt core bundle is 23 bytes smaller than its committed counterpart.
